### PR TITLE
feat: select all text in input fields when they receive focus

### DIFF
--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -121,6 +121,16 @@ func (m *Modal) AddInputFields(labels []string, texts []string) *Modal {
 						m.changed(i, text)
 					}
 				})
+			input.SetFocusFunc(func() {
+				// Select all text when the field receives focus.
+				if input.GetText() != "" {
+					input.InputHandler()(tcell.NewEventKey(tcell.KeyCtrlL, 0, tcell.ModNone), nil)
+				}
+			})
+			input.SetBlurFunc(func() {
+				// Replace the text with itself on blur to clear the selection state.
+				input.SetText(input.GetText())
+			})
 			m.form.AddFormItem(input)
 		}(index, label)
 	}


### PR DESCRIPTION
## Summary
- When an input field in the TUI modal receives focus, all existing text is automatically selected
- This improves UX when editing existing snippets — users can immediately overwrite the pre-filled value without manually selecting or clearing it

## Changes
- Added `SetFocusFunc` to each input field in `Modal.AddInputFields`: sends a `Ctrl+L` event to select all text if the field is non-empty
- Added `SetBlurFunc` to reset the selection state on blur by reassigning the current text to itself (avoids deadlock with `InputHandler`'s internal mutex)

## Test Plan
- [x] Run `linippet edit` on an existing snippet with pre-filled arguments, confirm all text in each input field is selected on focus
- [x] Tab between multiple input fields and confirm each field selects all its text when focused
- [x] Confirm that typing immediately after focusing an input field replaces the selected text
- [x] Confirm that blurring a field (Tab/Enter) does not crash or deadlock the TUI

## Screenshots

Select all text when the input focused.
<img width="506" height="239" alt="image" src="https://github.com/user-attachments/assets/3318a08c-8825-4120-b021-0b108aa5209e" />
