### PR TITLE
feat: improve modal text display with snippet preview and layout adjustments

### DIFF
--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -98,8 +98,9 @@ func (m *Modal) SetChangedFunc(handler func(inputIndex int, inputValue string)) 
 	return m
 }
 
-func (m *Modal) AddTextView(label string) *Modal {
-	view := tview.NewTextView().SetLabel(label).SetScrollable(false)
+func (m *Modal) AddTextView(text string) *Modal {
+	view := tview.NewTextView().SetScrollable(false)
+	view.SetText(text)
 	m.form.AddFormItem(view)
 	m.textView = view
 	return m

--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -35,7 +35,7 @@ func NewModal() *Modal {
 	})
 	m.frame = tview.NewFrame(m.form).SetBorders(0, 0, 1, 0, 0, 0)
 	m.frame.SetBackgroundColor(tcell.ColorDefault).
-		SetBorderPadding(1, 1, 1, 1)
+		SetBorderPadding(1, 1, 2, 2)
 	return m
 }
 
@@ -213,9 +213,9 @@ func (m *Modal) Draw(screen tcell.Screen) {
 
 	// Reset the text and find out how wide it is.
 	m.frame.Clear()
-	lines := tview.WordWrap(m.text, width)
+	lines := tview.WordWrap(m.text, width-2)
 	for _, line := range lines {
-		m.frame.AddText(line, true, tview.AlignCenter, m.textColor)
+		m.frame.AddText(line, true, tview.AlignLeft, m.textColor)
 	}
 
 	// Set the modal's position and size.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/muleyuck/linippet/internal/fuzzy_search"
@@ -30,9 +29,9 @@ func NewCreateTui() *OnlyModalTui {
 	app := tview.NewApplication()
 	modal := NewModal().
 		AddInputFields([]string{""}, nil).
-		AddTextView("").
+		AddTextView("Syntax: ${{name}} or ${{name:default}}").
 		AddButtons([]string{"OK", "Cancel"}).
-		SetText("Enter your new snippet\nYou can set argument : ${{arg_name}} or ${{arg_name:default}}")
+		SetText("$ ")
 	app.SetRoot(modal, true)
 	return &OnlyModalTui{
 		tui:   &tui{app: app},
@@ -43,7 +42,7 @@ func NewCreateTui() *OnlyModalTui {
 func (t *OnlyModalTui) SetAction() {
 	t.modal.SetChangedFunc(func(inputIndex int, inputValue string) {
 		t.Result = inputValue
-		t.modal.textView.SetText(argDisplayText(inputValue))
+		t.modal.SetText("$ " + snippetPreviewText(inputValue))
 	})
 	t.modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 		if buttonLabel == "Cancel" || buttonIndex == -1 {
@@ -258,7 +257,7 @@ func (t *listModalTui) setRootModal(currentText string) *Modal {
 	modal := NewModal().
 		AddInputFields(argNames, t.linippetArgs).
 		AddButtons([]string{"OK", "Cancel"}).
-		SetText(currentText)
+		SetText("$ " + snippetPreviewText(currentText))
 	modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 		if buttonLabel == "Cancel" || buttonIndex == -1 {
 			t.flex.RemoveItem(modal)
@@ -276,10 +275,10 @@ func (t *listModalTui) setRootModal(currentText string) *Modal {
 		t.linippetArgs[inputIndex] = inputValue
 		result, err := snippet.ReplaceSnippet(currentText, t.linippetArgs)
 		if err != nil {
-			modal.SetText(currentText)
+			modal.SetText("$ " + currentText)
 			return
 		}
-		modal.SetText(result)
+		modal.SetText("$ " + result)
 	})
 	modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
@@ -294,34 +293,37 @@ func (t *listModalTui) setRootModal(currentText string) *Modal {
 	return modal
 }
 
-func argDisplayText(inputValue string) string {
-	args := snippet.ExtractSnippetArgsWithDefaults(inputValue)
+func snippetPreviewText(snippetText string) string {
+	args := snippet.ExtractSnippetArgsWithDefaults(snippetText)
 	if len(args) == 0 {
-		return ""
+		return snippetText
 	}
-	argStrs := make([]string, len(args))
-	for i, a := range args {
-		if a.Default != "" {
-			argStrs[i] = fmt.Sprintf("%s (default: %s)", a.Name, a.Default)
+	previewArgs := make([]string, len(args))
+	for i, arg := range args {
+		if arg.Default != "" {
+			previewArgs[i] = arg.Default
 		} else {
-			argStrs[i] = a.Name
+			previewArgs[i] = "<" + arg.Name + ">"
 		}
 	}
-	return "This snippet have following arguments\n " + strings.Join(argStrs, "\n ")
+	result, err := snippet.ReplaceSnippet(snippetText, previewArgs)
+	if err != nil {
+		return snippetText
+	}
+	return result
 }
 
 func (t *listModalTui) setEditModal(currentText string) *Modal {
 	modal := NewModal().
 		AddInputFields([]string{""}, []string{currentText}).
-		AddTextView("").
+		AddTextView("Syntax: ${{name}} or ${{name:default}}").
 		AddButtons([]string{"OK", "Cancel"}).
-		SetText("Edit snippet\nYou can set argument : ${{arg_name}} or ${{arg_name:default}}")
+		SetText("$ " + snippetPreviewText(currentText))
 
 	t.Result = currentText
-	modal.textView.SetText(argDisplayText(currentText))
 	modal.SetChangedFunc(func(inputIndex int, inputValue string) {
 		t.Result = inputValue
-		modal.textView.SetText(argDisplayText(inputValue))
+		modal.SetText("$ " + snippetPreviewText(inputValue))
 	})
 	modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 		if buttonLabel == "Cancel" || buttonIndex == -1 {


### PR DESCRIPTION
## Summary
- Improved modal text display to show a resolved snippet preview with arguments substituted
- Changed text alignment from center to left and adjusted padding

## Changes
- Changed text alignment to `AlignLeft` in `Modal.Draw()` and adjusted word-wrap width
- Updated `SetBorderPadding` left/right padding from `1,1` to `2,2`
- Changed `AddTextView` signature from `label` to `text`, setting text directly on the view
- Renamed and reimplemented `argDisplayText` as `snippetPreviewText`: now returns a preview string with arguments replaced by their default values or `<name>` placeholders
- Display `Syntax: ${{name}} or ${{name:default}}` hint in the text view for create/edit modals
- Show modal header text in `$ <snippet preview>` format

## Test Plan
- [x] Run `linippet create` and confirm the snippet input form is displayed
- [x] Enter a snippet without arguments (e.g. `echo hello`) and confirm the header shows `$ echo hello`
- [x] Enter a snippet with a default argument (e.g. `echo ${{msg:world}}`) and confirm the header shows `$ echo world`
- [x] Enter a snippet with an argument without a default (e.g. `echo ${{msg}}`) and confirm the header shows `$ echo <msg>`
- [x] Select a snippet from the list and confirm the argument input modal shows the same preview behavior
- [x] Run `linippet edit` and confirm the `Syntax: ${{name}} or ${{name:default}}` hint is displayed in the text view

## Screenshots

create a new snippet: `echo hello`
<img width="513" height="257" alt="image" src="https://github.com/user-attachments/assets/c81b4b76-d2bb-494b-b8e6-d842736f2e65" />

create a new snippet: `echo ${{msg:world}}`
<img width="514" height="246" alt="image" src="https://github.com/user-attachments/assets/0c7a0d79-12d1-4413-93a9-f2d904917845" />

create a new snippet: `echo ${{msg}}`
<img width="509" height="248" alt="image" src="https://github.com/user-attachments/assets/4bd438f2-6e55-4bb5-a3bb-680db796a23a" />

