### PR TITLE
feat: write JSON with indented formatting

### DIFF
--- a/internal/linippet/linippet.go
+++ b/internal/linippet/linippet.go
@@ -95,7 +95,7 @@ func writeLinippets(linippets Linippets) (err error) {
 			err = deferErr
 		}
 	}()
-	out, err := json.Marshal(&linippets)
+	out, err := json.MarshalIndent(&linippets, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Changed JSON serialization of the snippet data file from compact to indented (2-space) format for improved human readability.

## Changes
- `internal/linippet/linippet.go`: Replace `json.Marshal` with `json.MarshalIndent` (2-space indent) in `writeLinippets`

## Test Plan
- [x] **Before/After comparison**: Add a snippet via `linippet create`, then open `~/.linippet/linippet.json`. Confirm the file is now pretty-printed with 2-space indentation (previously all data appeared on a single compact line).
- [x] **Read indented JSON**: With an existing indented JSON data file in place, run `linippet` to browse snippets and confirm all entries are loaded and displayed correctly.
- [x] **Round-trip**: Edit a snippet via `linippet edit`, save, and re-open the JSON file to confirm it remains properly indented after a write cycle.